### PR TITLE
Add shift summary, config, and heartbeat endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ teams can keep up with high-volume events.
 ### Authentication & Devices
 - `POST /api/mobile/login` — username/password login that returns a bearer token and staff profile
 - `POST /api/mobile/devices/register` — register APNs tokens for the signed-in staff member
+- `POST /api/mobile/devices/heartbeat` — capture liveness pings to record `last_seen` timestamps for devices
 
 ### Shift Operations
 - `GET /api/mobile/trucks` — list active trucks the staff member can operate
@@ -17,6 +18,9 @@ teams can keep up with high-volume events.
 - `POST /api/mobile/shift/checkin` — begin a shift at a location
 - `POST /api/mobile/shift/{id}/checkout` — close out a shift and notify connected devices
 - `POST /api/mobile/shift/{id}/pause` / `POST /api/mobile/shift/{id}/resume` — manage temporary pauses
+- `GET /api/mobile/shift/{id}/config` — view throttle and slot capacity configuration for the shift
+- `PATCH /api/mobile/shift/{id}/config` — adjust throttle/slot capacity values in real time
+- `GET /api/mobile/shift/{id}/summary` — aggregate order counts, revenue, and average prep time metrics
 
 ### Menu & Inventory
 - `GET /api/mobile/shift/{id}/menu` — fetch base menu items with per-shift overrides

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # FusionX Backend Roadmap
 
-_Last updated: 2024-02-16_
+_Last updated: 2024-03-01_
 
 ## Legend
 - [x] Completed
@@ -20,9 +20,9 @@ _Last updated: 2024-02-16_
 ## Phase 1 – Operational MVP (In progress)
 - [x] Provide mobile endpoint to list active trucks a staff member can act on (Iteration 1)
 - [x] Provide mobile endpoint to list active service locations for shift check-in (Iteration 1)
-- [ ] Add per-shift summary endpoint (order counts, revenue, average prep time)
-- [ ] Expose staff-accessible configuration for throttle and slot capacity adjustments
-- [ ] Deliver heartbeat endpoint so devices can report liveness / capture last_seen timestamps
+- [x] Add per-shift summary endpoint (order counts, revenue, average prep time)
+- [x] Expose staff-accessible configuration for throttle and slot capacity adjustments
+- [x] Deliver heartbeat endpoint so devices can report liveness / capture last_seen timestamps
 
 ## Phase 2 – Menu & Inventory Management
 - [ ] CRUD endpoints for menu items (name, description, base price)
@@ -76,3 +76,4 @@ _Last updated: 2024-02-16_
 
 ### Iteration History
 - **Iteration 1 (2024-02-16):** Bootstrapped roadmap, added truck & location discovery endpoints for the mobile client, refreshed README to describe available capabilities.
+- **Iteration 2 (2024-03-01):** Added device heartbeat tracking, per-shift configuration management, and summary reporting endpoints for mobile clients.

--- a/app/models.py
+++ b/app/models.py
@@ -2,12 +2,14 @@ from typing import Optional, List
 from datetime import datetime, timezone
 from sqlmodel import SQLModel, Field
 
+
 class StaffRole(str):
     OWNER = "Owner"
     MANAGER = "Manager"
     TRUCK_LEAD = "TruckLead"
     COOK = "Cook"
     CASHIER = "Cashier"
+
 
 class Staff(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -17,6 +19,7 @@ class Staff(SQLModel, table=True):
     role: str = StaffRole.TRUCK_LEAD
     truck_id: Optional[int] = Field(default=None, foreign_key="truck.id")
 
+
 class Device(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     staff_id: int = Field(foreign_key="staff.id")
@@ -24,6 +27,8 @@ class Device(SQLModel, table=True):
     platform: str = "ios"
     app_version: str = "0"
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_seen_at: Optional[datetime] = None
+
 
 class Truck(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -31,6 +36,7 @@ class Truck(SQLModel, table=True):
     capacity: int = 12
     tz: str = "America/Moncton"
     active: bool = True
+
 
 class Location(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -41,10 +47,12 @@ class Location(SQLModel, table=True):
     tax_region: str = "NB"
     geofence_m: int = 300
 
+
 class ShiftStatus(str):
     CHECKED_IN = "CHECKED_IN"
     PAUSED = "PAUSED"
     CHECKED_OUT = "CHECKED_OUT"
+
 
 class TruckShift(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -60,11 +68,13 @@ class TruckShift(SQLModel, table=True):
     lat: float = 0.0
     lon: float = 0.0
 
+
 class MenuItem(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     description: str = ""
     base_price_cents: int
+
 
 class TruckMenuItem(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -77,6 +87,7 @@ class TruckMenuItem(SQLModel, table=True):
     low_stock_threshold: int = 2
     prep_time_sec: int = 300
 
+
 class OrderState(str):
     NEW = "NEW"
     PAID = "PAID"
@@ -86,6 +97,7 @@ class OrderState(str):
     PICKED_UP = "PICKED_UP"
     CANCELED = "CANCELED"
     REFUNDED = "REFUNDED"
+
 
 class Order(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -98,6 +110,8 @@ class Order(SQLModel, table=True):
     tip_cents: int = 0
     total_cents: int = 0
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    prep_completed_at: Optional[datetime] = None
+
 
 class OrderItem(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/app/routers/mobile.py
+++ b/app/routers/mobile.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
-from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, Body
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    WebSocket,
+    WebSocketDisconnect,
+    Body,
+)
 from fastapi.responses import JSONResponse
 from sqlmodel import Session, select
 from typing import Any, Dict, List, Optional
@@ -9,16 +16,27 @@ import asyncio, json
 from ..db import get_session
 from ..auth import require_auth, make_token, hash_pw
 from ..models import (
-    Staff, Device, Truck, TruckShift, ShiftStatus,
-    Location, MenuItem, TruckMenuItem,
-    Order, OrderItem, OrderState
+    Staff,
+    Device,
+    Truck,
+    TruckShift,
+    ShiftStatus,
+    Location,
+    MenuItem,
+    TruckMenuItem,
+    Order,
+    OrderItem,
+    OrderState,
 )
 from ..hub import hub
 
 router = APIRouter(prefix="/api/mobile", tags=["mobile"])
 
+
 @router.post("/login")
-def mobile_login(payload: Dict[str, str] = Body(...), session: Session = Depends(get_session)):
+def mobile_login(
+    payload: Dict[str, str] = Body(...), session: Session = Depends(get_session)
+):
     username = (payload.get("username") or "").strip()
     password = payload.get("password") or ""
     st = session.exec(select(Staff).where(Staff.username == username)).first()
@@ -27,30 +45,88 @@ def mobile_login(payload: Dict[str, str] = Body(...), session: Session = Depends
     tok = make_token(st)
     return {"token": tok, "staff": {"id": st.id, "name": st.name, "role": st.role}}
 
+
 @router.post("/devices/register", status_code=204)
-def register_device(payload: Dict[str, str] = Body(...), staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def register_device(
+    payload: Dict[str, str] = Body(...),
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     token = payload.get("apns_token")
     if not token:
         raise HTTPException(400, "apns_token required")
-    dev = session.exec(select(Device).where(Device.apns_token == token, Device.staff_id == staff.id)).first()
+    dev = session.exec(
+        select(Device).where(Device.apns_token == token, Device.staff_id == staff.id)
+    ).first()
+    now = datetime.now(timezone.utc)
     if not dev:
-        dev = Device(staff_id=staff.id, apns_token=token, platform=payload.get("platform","ios"), app_version=payload.get("app_version","0"))
-        session.add(dev)
-        session.commit()
+        dev = Device(
+            staff_id=staff.id,
+            apns_token=token,
+            platform=payload.get("platform", "ios"),
+            app_version=payload.get("app_version", "0"),
+            last_seen_at=now,
+        )
+    else:
+        dev.platform = payload.get("platform", dev.platform)
+        dev.app_version = payload.get("app_version", dev.app_version)
+        dev.last_seen_at = now
+    session.add(dev)
+    session.commit()
     return JSONResponse(status_code=204, content=None)
 
+
+@router.post("/devices/heartbeat", status_code=204)
+def device_heartbeat(
+    payload: Dict[str, str] = Body(...),
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    token = payload.get("apns_token") or payload.get("device_token")
+    dev_id = payload.get("device_id")
+    query = select(Device).where(Device.staff_id == staff.id)
+    if token:
+        query = query.where(Device.apns_token == token)
+    elif dev_id:
+        try:
+            dev_id_int = int(dev_id)
+        except (TypeError, ValueError):
+            raise HTTPException(400, "device_id must be an integer")
+        query = query.where(Device.id == dev_id_int)
+    else:
+        raise HTTPException(400, "apns_token or device_id required")
+    dev = session.exec(query).first()
+    if not dev:
+        raise HTTPException(404, "device not found")
+    dev.last_seen_at = datetime.now(timezone.utc)
+    session.add(dev)
+    session.commit()
+    return JSONResponse(status_code=204, content=None)
+
+
 @router.get("/shift/active")
-def active_shift(staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def active_shift(
+    staff: Staff = Depends(require_auth), session: Session = Depends(get_session)
+):
     if not staff.truck_id:
         return {}
-    sh = session.exec(select(TruckShift)
-        .where(TruckShift.truck_id == staff.truck_id, TruckShift.status != ShiftStatus.CHECKED_OUT)
+    sh = session.exec(
+        select(TruckShift)
+        .where(
+            TruckShift.truck_id == staff.truck_id,
+            TruckShift.status != ShiftStatus.CHECKED_OUT,
+        )
         .order_by(TruckShift.id.desc())
     ).first()
     return sh or {}
 
+
 @router.post("/shift/checkin")
-def checkin(payload: Dict[str, int] = Body(...), staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def checkin(
+    payload: Dict[str, int] = Body(...),
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     truck_id = payload.get("truck_id") or staff.truck_id
     location_id = payload.get("location_id")
     if not truck_id or not location_id:
@@ -58,45 +134,138 @@ def checkin(payload: Dict[str, int] = Body(...), staff: Staff = Depends(require_
     loc = session.get(Location, location_id)
     if not loc:
         raise HTTPException(404, "location not found")
-    for prev in session.exec(select(TruckShift).where(TruckShift.truck_id == truck_id, TruckShift.status != ShiftStatus.CHECKED_OUT)).all():
+    for prev in session.exec(
+        select(TruckShift).where(
+            TruckShift.truck_id == truck_id,
+            TruckShift.status != ShiftStatus.CHECKED_OUT,
+        )
+    ).all():
         prev.status = ShiftStatus.CHECKED_OUT
         prev.ends_at = datetime.now(timezone.utc)
         session.add(prev)
-    shift = TruckShift(truck_id=truck_id, location_id=location_id, status=ShiftStatus.CHECKED_IN, lat=loc.lat, lon=loc.lon)
-    session.add(shift); session.commit(); session.refresh(shift)
+    shift = TruckShift(
+        truck_id=truck_id,
+        location_id=location_id,
+        status=ShiftStatus.CHECKED_IN,
+        lat=loc.lat,
+        lon=loc.lon,
+    )
+    session.add(shift)
+    session.commit()
+    session.refresh(shift)
     return shift
 
+
 @router.post("/shift/{shift_id}/checkout", status_code=204)
-def checkout(shift_id: int, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def checkout(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     sh = session.get(TruckShift, shift_id)
-    if not sh: raise HTTPException(404, "shift not found")
-    sh.status = ShiftStatus.CHECKED_OUT; sh.ends_at = datetime.now(timezone.utc)
-    session.add(sh); session.commit()
-    asyncio.create_task(hub.emit(shift_id, {"event":"resume"}))
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    sh.status = ShiftStatus.CHECKED_OUT
+    sh.ends_at = datetime.now(timezone.utc)
+    session.add(sh)
+    session.commit()
+    asyncio.create_task(hub.emit(shift_id, {"event": "resume"}))
     return JSONResponse(status_code=204, content=None)
 
+
 @router.post("/shift/{shift_id}/pause")
-def pause_shift(shift_id: int, payload: Dict[str, Any] = Body(...), staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
-    minutes = int(payload.get("minutes") or 10); reason = payload.get("reason") or "Paused"
+def pause_shift(
+    shift_id: int,
+    payload: Dict[str, Any] = Body(...),
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    minutes = int(payload.get("minutes") or 10)
+    reason = payload.get("reason") or "Paused"
     sh = session.get(TruckShift, shift_id)
-    if not sh: raise HTTPException(404, "shift not found")
-    if sh.status == ShiftStatus.CHECKED_OUT: raise HTTPException(400, "shift checked out")
-    sh.status = ShiftStatus.PAUSED; sh.resume_at = datetime.now(timezone.utc) + timedelta(minutes=minutes)
-    session.add(sh); session.commit()
-    asyncio.create_task(hub.emit(shift_id, {"event":"pause", "reason": reason}))
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    if sh.status == ShiftStatus.CHECKED_OUT:
+        raise HTTPException(400, "shift checked out")
+    sh.status = ShiftStatus.PAUSED
+    sh.resume_at = datetime.now(timezone.utc) + timedelta(minutes=minutes)
+    session.add(sh)
+    session.commit()
+    asyncio.create_task(hub.emit(shift_id, {"event": "pause", "reason": reason}))
     return {"status": sh.status, "resume_at": sh.resume_at}
 
+
 @router.post("/shift/{shift_id}/resume")
-def resume_shift(shift_id: int, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def resume_shift(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     sh = session.get(TruckShift, shift_id)
-    if not sh: raise HTTPException(404, "shift not found")
-    if sh.status == ShiftStatus.CHECKED_OUT: raise HTTPException(400, "shift checked out")
-    sh.status = ShiftStatus.CHECKED_IN; sh.resume_at = None
-    session.add(sh); session.commit()
-    asyncio.create_task(hub.emit(shift_id, {"event":"resume"}))
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    if sh.status == ShiftStatus.CHECKED_OUT:
+        raise HTTPException(400, "shift checked out")
+    sh.status = ShiftStatus.CHECKED_IN
+    sh.resume_at = None
+    session.add(sh)
+    session.commit()
+    asyncio.create_task(hub.emit(shift_id, {"event": "resume"}))
     return {"status": sh.status}
 
-from pydantic import BaseModel
+
+from pydantic import BaseModel, Field
+
+
+class ShiftConfig(BaseModel):
+    throttlePer5Min: int
+    slotCapacityPerMin: int
+
+
+class ShiftConfigPayload(BaseModel):
+    throttlePer5Min: Optional[int] = Field(default=None, ge=1)
+    slotCapacityPerMin: Optional[int] = Field(default=None, ge=1)
+
+
+def _shift_to_config(shift: TruckShift) -> ShiftConfig:
+    return ShiftConfig(
+        throttlePer5Min=shift.throttle_per_5m,
+        slotCapacityPerMin=shift.slot_capacity_per_min,
+    )
+
+
+@router.get("/shift/{shift_id}/config", response_model=ShiftConfig)
+def get_shift_config(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    sh = session.get(TruckShift, shift_id)
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    return _shift_to_config(sh)
+
+
+@router.patch("/shift/{shift_id}/config", response_model=ShiftConfig)
+def update_shift_config(
+    shift_id: int,
+    payload: ShiftConfigPayload,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    sh = session.get(TruckShift, shift_id)
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    if payload.throttlePer5Min is None and payload.slotCapacityPerMin is None:
+        raise HTTPException(400, "No configuration changes provided")
+    if payload.throttlePer5Min is not None:
+        sh.throttle_per_5m = payload.throttlePer5Min
+    if payload.slotCapacityPerMin is not None:
+        sh.slot_capacity_per_min = payload.slotCapacityPerMin
+    session.add(sh)
+    session.commit()
+    asyncio.create_task(hub.emit(shift_id, {"event": "config_updated"}))
+    return _shift_to_config(sh)
 
 
 class TruckInfo(BaseModel):
@@ -111,8 +280,12 @@ class TruckEnvelope(BaseModel):
 
 
 @router.get("/trucks", response_model=TruckEnvelope)
-def list_trucks(staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
-    query = select(Truck).where(Truck.active == True)  # noqa: E712 - SQLModel bool comparison
+def list_trucks(
+    staff: Staff = Depends(require_auth), session: Session = Depends(get_session)
+):
+    query = select(Truck).where(
+        Truck.active == True
+    )  # noqa: E712 - SQLModel bool comparison
     if staff.truck_id:
         query = query.where(Truck.id == staff.truck_id)
     trucks = session.exec(query.order_by(Truck.name.asc())).all()
@@ -139,7 +312,9 @@ class LocationEnvelope(BaseModel):
 
 
 @router.get("/locations", response_model=LocationEnvelope)
-def list_locations(_staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def list_locations(
+    _staff: Staff = Depends(require_auth), session: Session = Depends(get_session)
+):
     locations = session.exec(select(Location).order_by(Location.name.asc())).all()
     return {
         "locations": [
@@ -161,68 +336,165 @@ def list_locations(_staff: Staff = Depends(require_auth), session: Session = Dep
 class MenuEnvelope(BaseModel):
     items: List[dict]
 
+
 @router.get("/shift/{shift_id}/menu", response_model=MenuEnvelope)
-def shift_menu(shift_id: int, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def shift_menu(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     base = session.exec(select(MenuItem)).all()
     out: List[dict] = []
     for m in base:
-        tmi = session.exec(select(TruckMenuItem).where(TruckMenuItem.shift_id == shift_id, TruckMenuItem.menu_item_id == m.id)).first()
+        tmi = session.exec(
+            select(TruckMenuItem).where(
+                TruckMenuItem.shift_id == shift_id, TruckMenuItem.menu_item_id == m.id
+            )
+        ).first()
         if not tmi:
-            tmi = TruckMenuItem(shift_id=shift_id, menu_item_id=m.id); session.add(tmi); session.commit(); session.refresh(tmi)
-        price = tmi.price_override_cents if tmi.price_override_cents is not None else m.base_price_cents
-        out.append({"id": m.id, "name": m.name, "priceCents": price, "stockCount": tmi.stock_count, "outOfStock": tmi.out_of_stock})
+            tmi = TruckMenuItem(shift_id=shift_id, menu_item_id=m.id)
+            session.add(tmi)
+            session.commit()
+            session.refresh(tmi)
+        price = (
+            tmi.price_override_cents
+            if tmi.price_override_cents is not None
+            else m.base_price_cents
+        )
+        out.append(
+            {
+                "id": m.id,
+                "name": m.name,
+                "priceCents": price,
+                "stockCount": tmi.stock_count,
+                "outOfStock": tmi.out_of_stock,
+            }
+        )
     return {"items": out}
+
 
 class InventoryUpdate(BaseModel):
     menu_item_id: int
     stock_count: Optional[int] = None
     out_of_stock: Optional[bool] = None
 
+
 class InventoryPayload(BaseModel):
     updates: List[InventoryUpdate]
 
+
 @router.patch("/shift/{shift_id}/inventory", status_code=204)
-def update_inventory(shift_id: int, payload: InventoryPayload, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def update_inventory(
+    shift_id: int,
+    payload: InventoryPayload,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     lows: List[int] = []
     for upd in payload.updates:
-        tmi = session.exec(select(TruckMenuItem).where(TruckMenuItem.shift_id == shift_id, TruckMenuItem.menu_item_id == upd.menu_item_id)).first()
+        tmi = session.exec(
+            select(TruckMenuItem).where(
+                TruckMenuItem.shift_id == shift_id,
+                TruckMenuItem.menu_item_id == upd.menu_item_id,
+            )
+        ).first()
         if not tmi:
-            tmi = TruckMenuItem(shift_id=shift_id, menu_item_id=upd.menu_item_id); session.add(tmi); session.commit(); session.refresh(tmi)
-        if upd.stock_count is not None: tmi.stock_count = max(0, upd.stock_count)
-        if upd.out_of_stock is not None: tmi.out_of_stock = bool(upd.out_of_stock)
-        session.add(tmi); session.commit()
-        if tmi.stock_count is not None and tmi.stock_count <= (tmi.low_stock_threshold or 0):
+            tmi = TruckMenuItem(shift_id=shift_id, menu_item_id=upd.menu_item_id)
+            session.add(tmi)
+            session.commit()
+            session.refresh(tmi)
+        if upd.stock_count is not None:
+            tmi.stock_count = max(0, upd.stock_count)
+        if upd.out_of_stock is not None:
+            tmi.out_of_stock = bool(upd.out_of_stock)
+        session.add(tmi)
+        session.commit()
+        if tmi.stock_count is not None and tmi.stock_count <= (
+            tmi.low_stock_threshold or 0
+        ):
             lows.append(upd.menu_item_id)
     for mid in lows:
-        asyncio.create_task(hub.emit(shift_id, {"event":"low_stock", "menu_item_id": mid}))
+        asyncio.create_task(
+            hub.emit(shift_id, {"event": "low_stock", "menu_item_id": mid})
+        )
     return JSONResponse(status_code=204, content=None)
+
 
 # KDS
 class TicketItem(BaseModel):
-    name: str; qty: int; mods: List[str] = []
+    name: str
+    qty: int
+    mods: List[str] = []
+
 
 class KDSTicket(BaseModel):
-    order_id: int; created_at: datetime; state: str; items: List[TicketItem]
+    order_id: int
+    created_at: datetime
+    state: str
+    items: List[TicketItem]
+
 
 class TicketEnvelope(BaseModel):
     tickets: List[KDSTicket]
 
+
 @router.get("/shift/{shift_id}/kds", response_model=TicketEnvelope)
-def kds(shift_id: int, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
-    orders = session.exec(select(Order)
-        .where(Order.shift_id == shift_id, Order.state.in_([
-            OrderState.NEW, OrderState.PAID, OrderState.IN_QUEUE, OrderState.IN_PROGRESS, OrderState.READY
-        ])).order_by(Order.created_at.asc())
+def kds(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    orders = session.exec(
+        select(Order)
+        .where(
+            Order.shift_id == shift_id,
+            Order.state.in_(
+                [
+                    OrderState.NEW,
+                    OrderState.PAID,
+                    OrderState.IN_QUEUE,
+                    OrderState.IN_PROGRESS,
+                    OrderState.READY,
+                ]
+            ),
+        )
+        .order_by(Order.created_at.asc())
     ).all()
     tickets: List[KDSTicket] = []
     for o in orders:
         items = session.exec(select(OrderItem).where(OrderItem.order_id == o.id)).all()
-        tickets.append(KDSTicket(order_id=o.id, created_at=o.created_at, state=o.state,
-            items=[TicketItem(name=it.name, qty=it.qty, mods=json.loads(it.modifiers_json or "[]")) for it in items]))
+        tickets.append(
+            KDSTicket(
+                order_id=o.id,
+                created_at=o.created_at,
+                state=o.state,
+                items=[
+                    TicketItem(
+                        name=it.name,
+                        qty=it.qty,
+                        mods=json.loads(it.modifiers_json or "[]"),
+                    )
+                    for it in items
+                ],
+            )
+        )
     return {"tickets": tickets}
+
 
 class AdvancePayload(BaseModel):
     to: str
+
+
+class ShiftSummary(BaseModel):
+    shiftId: int
+    status: str
+    startedAt: datetime
+    endedAt: Optional[datetime]
+    totalOrders: int
+    revenueCents: int
+    ordersByState: Dict[str, int]
+    averagePrepSeconds: Optional[int]
+
 
 ALLOWED_ADVANCES = {
     OrderState.PAID: [OrderState.IN_QUEUE, OrderState.IN_PROGRESS],
@@ -231,12 +503,59 @@ ALLOWED_ADVANCES = {
     OrderState.READY: [OrderState.PICKED_UP],
 }
 
+
 @router.post("/order/{order_id}/advance")
-def advance(order_id: int, payload: AdvancePayload, staff: Staff = Depends(require_auth), session: Session = Depends(get_session)):
+def advance(
+    order_id: int,
+    payload: AdvancePayload,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
     o = session.get(Order, order_id)
-    if not o: raise HTTPException(404, "order not found")
+    if not o:
+        raise HTTPException(404, "order not found")
     allowed = ALLOWED_ADVANCES.get(o.state, [])
-    if payload.to not in allowed: raise HTTPException(400, f"Cannot advance from {o.state} to {payload.to}")
-    o.state = payload.to; session.add(o); session.commit()
-    asyncio.create_task(hub.emit(o.shift_id, {"event":"new_order", "order_id": o.id}))
+    if payload.to not in allowed:
+        raise HTTPException(400, f"Cannot advance from {o.state} to {payload.to}")
+    o.state = payload.to
+    if payload.to == OrderState.READY:
+        o.prep_completed_at = datetime.now(timezone.utc)
+    session.add(o)
+    session.commit()
+    asyncio.create_task(hub.emit(o.shift_id, {"event": "new_order", "order_id": o.id}))
     return {"state": o.state}
+
+
+@router.get("/shift/{shift_id}/summary", response_model=ShiftSummary)
+def shift_summary(
+    shift_id: int,
+    staff: Staff = Depends(require_auth),
+    session: Session = Depends(get_session),
+):
+    sh = session.get(TruckShift, shift_id)
+    if not sh:
+        raise HTTPException(404, "shift not found")
+    orders = session.exec(select(Order).where(Order.shift_id == shift_id)).all()
+    revenue = 0
+    orders_by_state: Dict[str, int] = {}
+    prep_durations: List[float] = []
+    for order in orders:
+        revenue += order.total_cents
+        orders_by_state[order.state] = orders_by_state.get(order.state, 0) + 1
+        if order.prep_completed_at:
+            duration = (order.prep_completed_at - order.created_at).total_seconds()
+            if duration >= 0:
+                prep_durations.append(duration)
+    avg_prep = (
+        int(sum(prep_durations) / len(prep_durations)) if prep_durations else None
+    )
+    return ShiftSummary(
+        shiftId=shift_id,
+        status=sh.status,
+        startedAt=sh.starts_at,
+        endedAt=sh.ends_at,
+        totalOrders=len(orders),
+        revenueCents=revenue,
+        ordersByState=orders_by_state,
+        averagePrepSeconds=avg_prep,
+    )


### PR DESCRIPTION
## Summary
- track device last_seen timestamps and order prep completion for new reporting
- add mobile API endpoints for device heartbeats, shift config updates, and per-shift summaries
- document the new capabilities and mark the roadmap progress

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d1dcf862408323ac580b58a20a54c4